### PR TITLE
リンク切れのURLを修正

### DIFF
--- a/01-introduction-to-oss.md
+++ b/01-introduction-to-oss.md
@@ -1,5 +1,5 @@
 ---
-theme : "Moon"
+theme: "Moon"
 customTheme: "custom-theme"
 transition: "none"
 slideNumber: true
@@ -45,20 +45,20 @@ OSS 勉強会 #1
 
 ### Open Source Initiative
 
-* オープンソースの定義
-    * https://opensource.org/osd （[和訳](https://ja.osdn.net/projects/opensource/wiki/Open_Source_Definition)）
-* オープンソースライセンス
-    * https://opensource.org/licenses （[和訳](https://ja.osdn.net/projects/opensource/wiki/licenses)）
-* Tips
-    * [オープンソースの誕生 - Shuji Sado -](https://shujisado.com/2017/05/17/612085/)
+- オープンソースの定義
+  - https://opensource.org/osd （[和訳](https://opensource.jp/osd/osd19)）
+- オープンソースライセンス
+  - https://opensource.org/licenses （[和訳](https://licenses.opensource.jp)）
+- Tips
+  - [オープンソースの誕生 - Shuji Sado -](https://shujisado.com/2017/05/17/612085/)
 
 ---
 
 ### Open Source Guides
 
-* オープンソースガイドライン
-    * https://opensource.guide （[和訳](https://opensource.guide/ja/)）
-    * https://github.com/github/opensource.guide
+- オープンソースガイドライン
+  - https://opensource.guide （[和訳](https://opensource.guide/ja/)）
+  - https://github.com/github/opensource.guide
 
 ---
 
@@ -68,34 +68,34 @@ OSS 勉強会 #1
 
 ### OSS 活動の種類
 
-* 自分のプロジェクトを公開・メンテナンスする
-* **既存のプロジェクトにコントリビュートする**
+- 自分のプロジェクトを公開・メンテナンスする
+- **既存のプロジェクトにコントリビュートする**
 
 ---
 
 ### 様々な "コントリビュート" の方法
 
-* https://opensource.guide/ja/how-to-contribute/
-* コードを書く（機能追加、バグ修正）
-* コードを書くことだけが OSS 活動ではない
-    * ドキュメントの改善
-        * 誤字脱字、リンク切れ、翻訳誤り、の報告・修正
-        * 最新バージョンへの追従、翻訳の追加
-    * バグの報告、未解決問題の再現報告
-    * これらも、立派な OSS への「貢献」
-        * "ユーザー" から "コントリビューター" へ
-* Tips
-    * メンテナー（コミッター）とコントリビューター
-    * https://opensource.guide/ja/leadership-and-governance/
+- https://opensource.guide/ja/how-to-contribute/
+- コードを書く（機能追加、バグ修正）
+- コードを書くことだけが OSS 活動ではない
+  - ドキュメントの改善
+    - 誤字脱字、リンク切れ、翻訳誤り、の報告・修正
+    - 最新バージョンへの追従、翻訳の追加
+  - バグの報告、未解決問題の再現報告
+  - これらも、立派な OSS への「貢献」
+    - "ユーザー" から "コントリビューター" へ
+- Tips
+  - メンテナー（コミッター）とコントリビューター
+  - https://opensource.guide/ja/leadership-and-governance/
 
 ---
 
 ### 何から始めればよいか
 
-* Good First Issue / Help Wanted
-* http://github-help-wanted.com/
-* https://goodfirstissue.dev/
-* 参考：[今すぐ始められるOSS活動 - Gunosy テックブログ -](https://tech.gunosy.io/entry/oss_first_contribution)
+- Good First Issue / Help Wanted
+- http://github-help-wanted.com/
+- https://goodfirstissue.dev/
+- 参考：[今すぐ始められる OSS 活動 - Gunosy テックブログ -](https://tech.gunosy.io/entry/oss_first_contribution)
 
 ---
 
@@ -105,53 +105,52 @@ OSS 勉強会 #1
 
 ### OSS と個人
 
-* モチベーション
-    * 技術的な課題の解決
-    * 自己実現
-* Tips
-    * [初めてOSS貢献体験と、それにより変化した考え方について - Money Forward Engineer's Blog -](https://moneyforward.com/engineers_blog/2019/12/10/oss-mindchange/)
-    * [趣味で作ったソフトウェアが海外企業に買われるまでの話 - knqyf263's blog - ](https://knqyf263.hatenablog.com/entry/2019/08/20/120713)
+- モチベーション
+  - 技術的な課題の解決
+  - 自己実現
+- Tips
+  - [初めて OSS 貢献体験と、それにより変化した考え方について - Money Forward Engineer's Blog -](https://moneyforward.com/engineers_blog/2019/12/10/oss-mindchange/)
+  - [趣味で作ったソフトウェアが海外企業に買われるまでの話 - knqyf263's blog - ](https://knqyf263.hatenablog.com/entry/2019/08/20/120713)
 
 ---
 
 ### OSS と組織
 
-* ソフトウェア開発業務で OSS を利用
-    * 現代のソフトウェア開発に OSS は欠かせない
-* 技術広報（エンジニアリング文化、オープン性）
-    * 自社技術を OSS として公開
-    * 従業員が OSS を公開、貢献
-    * 従業員の OSS 活動の推奨
-* 社会貢献
+- ソフトウェア開発業務で OSS を利用
+  - 現代のソフトウェア開発に OSS は欠かせない
+- 技術広報（エンジニアリング文化、オープン性）
+  - 自社技術を OSS として公開
+  - 従業員が OSS を公開、貢献
+  - 従業員の OSS 活動の推奨
+- 社会貢献
 
 ---
 
 ### Tips
 
-* OSS ポリシーを策定するテック企業
-    * [Ateam](https://www.a-tm.co.jp/news/corporate-17428/)
-    * [Cookpad](https://techlife.cookpad.com/entry/oss-policy)
-    * [Cybozu](https://blog.cybozu.io/entry/oss-policy)    
-    * [Gaiax](https://qiita.com/norinux/items/44b01075a9dc6f10ec29)
-    * [ZOZO Technologies](https://techblog.zozo.com/entry/oss-policy)
-* オープンソースビジネスに取り組む SI 企業のための企業ポリシー策定ガイドライン
-    * https://www.jisa.or.jp/Portals/0/report/16-J013.pdf
-    * 社団法人 情報サービス産業協会 オープンソース・ビジネス委員会
+- OSS ポリシーを策定するテック企業
+  - [Ateam](https://www.a-tm.co.jp/news/corporate-17428/)
+  - [Cookpad](https://techlife.cookpad.com/entry/oss-policy)
+  - [Cybozu](https://blog.cybozu.io/entry/oss-policy)
+  - [Gaiax](https://qiita.com/norinux/items/44b01075a9dc6f10ec29)
+  - [ZOZO Technologies](https://techblog.zozo.com/entry/oss-policy)
+- オープンソースビジネスに取り組む SI 企業のための企業ポリシー策定ガイドライン
+  - https://www.jisa.or.jp/Portals/0/report/16-J013.pdf
+  - 社団法人 情報サービス産業協会 オープンソース・ビジネス委員会
 
 ---
 
 ### OSS と社会
 
-* オープンデータ
-* CivicTech, Code for Japan
-    * 東京都 新型コロナウイルス感染症対策サイト
-        * https://github.com/tokyo-metropolitan-gov/covid19
-    * 新型コロナウイルス接触確認アプリ
-        * https://github.com/Covid-19Radar/Covid19Radar
-* 社会情勢への対応
-    * [Googleのセキュリティスキャナー「Tsunami」、名称がGitHubで議論呼ぶ　関係者が参加し釈明 - ITmedia -](https://www.itmedia.co.jp/news/articles/2007/01/news139.html)
-    * [GitHub、「マスター」「スレーブ」などの用語を見直し--人種差別撤廃に賛同 - CENT Japan -](https://japan.cnet.com/article/35155337/)
-
+- オープンデータ
+- CivicTech, Code for Japan
+  - 東京都 新型コロナウイルス感染症対策サイト
+    - https://github.com/tokyo-metropolitan-gov/covid19
+  - 新型コロナウイルス接触確認アプリ
+    - https://github.com/Covid-19Radar/Covid19Radar
+- 社会情勢への対応
+  - [Google のセキュリティスキャナー「Tsunami」、名称が GitHub で議論呼ぶ　関係者が参加し釈明 - ITmedia -](https://www.itmedia.co.jp/news/articles/2007/01/news139.html)
+  - [GitHub、「マスター」「スレーブ」などの用語を見直し--人種差別撤廃に賛同 - CENT Japan -](https://japan.cnet.com/article/35155337/)
 
 ---
 
@@ -159,11 +158,11 @@ OSS 勉強会 #1
 
 ---
 
-* 「批判」ではなく「感謝」と「提案」
-* 互いの意見を尊重した建設的な議論
-* 多様性を前提としたコミュニケーション
-* Tips
-    * [批判の文化が日本を技術後進国にしているかもしれないという話 - メソッド屋のブログ -](https://simplearchitect.hatenablog.com/entry/2020/06/22/083821	)
+- 「批判」ではなく「感謝」と「提案」
+- 互いの意見を尊重した建設的な議論
+- 多様性を前提としたコミュニケーション
+- Tips
+  - [批判の文化が日本を技術後進国にしているかもしれないという話 - メソッド屋のブログ -](https://simplearchitect.hatenablog.com/entry/2020/06/22/083821)
 
 ---
 

--- a/01-introduction-to-oss.md
+++ b/01-introduction-to-oss.md
@@ -1,5 +1,5 @@
 ---
-theme: "Moon"
+theme : "Moon"
 customTheme: "custom-theme"
 transition: "none"
 slideNumber: true
@@ -45,20 +45,20 @@ OSS 勉強会 #1
 
 ### Open Source Initiative
 
-- オープンソースの定義
-  - https://opensource.org/osd （[和訳](https://opensource.jp/osd/osd19)）
-- オープンソースライセンス
-  - https://opensource.org/licenses （[和訳](https://licenses.opensource.jp)）
-- Tips
-  - [オープンソースの誕生 - Shuji Sado -](https://shujisado.com/2017/05/17/612085/)
+* オープンソースの定義
+    * https://opensource.org/osd （[和訳](https://opensource.jp/osd/osd19)）
+* オープンソースライセンス
+    * https://opensource.org/licenses （[和訳](https://licenses.opensource.jp)）
+* Tips
+    * [オープンソースの誕生 - Shuji Sado -](https://shujisado.com/2017/05/17/612085/)
 
 ---
 
 ### Open Source Guides
 
-- オープンソースガイドライン
-  - https://opensource.guide （[和訳](https://opensource.guide/ja/)）
-  - https://github.com/github/opensource.guide
+* オープンソースガイドライン
+    * https://opensource.guide （[和訳](https://opensource.guide/ja/)）
+    * https://github.com/github/opensource.guide
 
 ---
 
@@ -68,34 +68,34 @@ OSS 勉強会 #1
 
 ### OSS 活動の種類
 
-- 自分のプロジェクトを公開・メンテナンスする
-- **既存のプロジェクトにコントリビュートする**
+* 自分のプロジェクトを公開・メンテナンスする
+* **既存のプロジェクトにコントリビュートする**
 
 ---
 
 ### 様々な "コントリビュート" の方法
 
-- https://opensource.guide/ja/how-to-contribute/
-- コードを書く（機能追加、バグ修正）
-- コードを書くことだけが OSS 活動ではない
-  - ドキュメントの改善
-    - 誤字脱字、リンク切れ、翻訳誤り、の報告・修正
-    - 最新バージョンへの追従、翻訳の追加
-  - バグの報告、未解決問題の再現報告
-  - これらも、立派な OSS への「貢献」
-    - "ユーザー" から "コントリビューター" へ
-- Tips
-  - メンテナー（コミッター）とコントリビューター
-  - https://opensource.guide/ja/leadership-and-governance/
+* https://opensource.guide/ja/how-to-contribute/
+* コードを書く（機能追加、バグ修正）
+* コードを書くことだけが OSS 活動ではない
+    * ドキュメントの改善
+        * 誤字脱字、リンク切れ、翻訳誤り、の報告・修正
+        * 最新バージョンへの追従、翻訳の追加
+    * バグの報告、未解決問題の再現報告
+    * これらも、立派な OSS への「貢献」
+        * "ユーザー" から "コントリビューター" へ
+* Tips
+    * メンテナー（コミッター）とコントリビューター
+    * https://opensource.guide/ja/leadership-and-governance/
 
 ---
 
 ### 何から始めればよいか
 
-- Good First Issue / Help Wanted
-- http://github-help-wanted.com/
-- https://goodfirstissue.dev/
-- 参考：[今すぐ始められる OSS 活動 - Gunosy テックブログ -](https://tech.gunosy.io/entry/oss_first_contribution)
+* Good First Issue / Help Wanted
+* http://github-help-wanted.com/
+* https://goodfirstissue.dev/
+* 参考：[今すぐ始められるOSS活動 - Gunosy テックブログ -](https://tech.gunosy.io/entry/oss_first_contribution)
 
 ---
 
@@ -105,52 +105,53 @@ OSS 勉強会 #1
 
 ### OSS と個人
 
-- モチベーション
-  - 技術的な課題の解決
-  - 自己実現
-- Tips
-  - [初めて OSS 貢献体験と、それにより変化した考え方について - Money Forward Engineer's Blog -](https://moneyforward.com/engineers_blog/2019/12/10/oss-mindchange/)
-  - [趣味で作ったソフトウェアが海外企業に買われるまでの話 - knqyf263's blog - ](https://knqyf263.hatenablog.com/entry/2019/08/20/120713)
+* モチベーション
+    * 技術的な課題の解決
+    * 自己実現
+* Tips
+    * [初めてOSS貢献体験と、それにより変化した考え方について - Money Forward Engineer's Blog -](https://moneyforward.com/engineers_blog/2019/12/10/oss-mindchange/)
+    * [趣味で作ったソフトウェアが海外企業に買われるまでの話 - knqyf263's blog - ](https://knqyf263.hatenablog.com/entry/2019/08/20/120713)
 
 ---
 
 ### OSS と組織
 
-- ソフトウェア開発業務で OSS を利用
-  - 現代のソフトウェア開発に OSS は欠かせない
-- 技術広報（エンジニアリング文化、オープン性）
-  - 自社技術を OSS として公開
-  - 従業員が OSS を公開、貢献
-  - 従業員の OSS 活動の推奨
-- 社会貢献
+* ソフトウェア開発業務で OSS を利用
+    * 現代のソフトウェア開発に OSS は欠かせない
+* 技術広報（エンジニアリング文化、オープン性）
+    * 自社技術を OSS として公開
+    * 従業員が OSS を公開、貢献
+    * 従業員の OSS 活動の推奨
+* 社会貢献
 
 ---
 
 ### Tips
 
-- OSS ポリシーを策定するテック企業
-  - [Ateam](https://www.a-tm.co.jp/news/corporate-17428/)
-  - [Cookpad](https://techlife.cookpad.com/entry/oss-policy)
-  - [Cybozu](https://blog.cybozu.io/entry/oss-policy)
-  - [Gaiax](https://qiita.com/norinux/items/44b01075a9dc6f10ec29)
-  - [ZOZO Technologies](https://techblog.zozo.com/entry/oss-policy)
-- オープンソースビジネスに取り組む SI 企業のための企業ポリシー策定ガイドライン
-  - https://www.jisa.or.jp/Portals/0/report/16-J013.pdf
-  - 社団法人 情報サービス産業協会 オープンソース・ビジネス委員会
+* OSS ポリシーを策定するテック企業
+    * [Ateam](https://www.a-tm.co.jp/news/corporate-17428/)
+    * [Cookpad](https://techlife.cookpad.com/entry/oss-policy)
+    * [Cybozu](https://blog.cybozu.io/entry/oss-policy)    
+    * [Gaiax](https://qiita.com/norinux/items/44b01075a9dc6f10ec29)
+    * [ZOZO Technologies](https://techblog.zozo.com/entry/oss-policy)
+* オープンソースビジネスに取り組む SI 企業のための企業ポリシー策定ガイドライン
+    * https://www.jisa.or.jp/Portals/0/report/16-J013.pdf
+    * 社団法人 情報サービス産業協会 オープンソース・ビジネス委員会
 
 ---
 
 ### OSS と社会
 
-- オープンデータ
-- CivicTech, Code for Japan
-  - 東京都 新型コロナウイルス感染症対策サイト
-    - https://github.com/tokyo-metropolitan-gov/covid19
-  - 新型コロナウイルス接触確認アプリ
-    - https://github.com/Covid-19Radar/Covid19Radar
-- 社会情勢への対応
-  - [Google のセキュリティスキャナー「Tsunami」、名称が GitHub で議論呼ぶ　関係者が参加し釈明 - ITmedia -](https://www.itmedia.co.jp/news/articles/2007/01/news139.html)
-  - [GitHub、「マスター」「スレーブ」などの用語を見直し--人種差別撤廃に賛同 - CENT Japan -](https://japan.cnet.com/article/35155337/)
+* オープンデータ
+* CivicTech, Code for Japan
+    * 東京都 新型コロナウイルス感染症対策サイト
+        * https://github.com/tokyo-metropolitan-gov/covid19
+    * 新型コロナウイルス接触確認アプリ
+        * https://github.com/Covid-19Radar/Covid19Radar
+* 社会情勢への対応
+    * [Googleのセキュリティスキャナー「Tsunami」、名称がGitHubで議論呼ぶ　関係者が参加し釈明 - ITmedia -](https://www.itmedia.co.jp/news/articles/2007/01/news139.html)
+    * [GitHub、「マスター」「スレーブ」などの用語を見直し--人種差別撤廃に賛同 - CENT Japan -](https://japan.cnet.com/article/35155337/)
+
 
 ---
 
@@ -158,11 +159,11 @@ OSS 勉強会 #1
 
 ---
 
-- 「批判」ではなく「感謝」と「提案」
-- 互いの意見を尊重した建設的な議論
-- 多様性を前提としたコミュニケーション
-- Tips
-  - [批判の文化が日本を技術後進国にしているかもしれないという話 - メソッド屋のブログ -](https://simplearchitect.hatenablog.com/entry/2020/06/22/083821)
+* 「批判」ではなく「感謝」と「提案」
+* 互いの意見を尊重した建設的な議論
+* 多様性を前提としたコミュニケーション
+* Tips
+    * [批判の文化が日本を技術後進国にしているかもしれないという話 - メソッド屋のブログ -](https://simplearchitect.hatenablog.com/entry/2020/06/22/083821    )
 
 ---
 


### PR DESCRIPTION
以下のリンクを修正しました。

- オープンソースの定義（和訳）：https://opensource.jp/osd/osd19/
- オープンソースライセンス（和訳）：https://licenses.opensource.jp/

「オープンソースの定義」の和訳のURLはバージョンが上がると変更されるので、以下のURLの方がいいかもしれません。

https://opensource.jp/osd/

よろしくお願いします。